### PR TITLE
Enable CTA Play Button

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -84,6 +84,7 @@
           :description="$store.getters['whatsOnNow/whatsOnNowDetails']"
           :description-link="$store.getters['whatsOnNow/whatsOnNowDetailsLink']"
           :file="$store.getters['whatsOnNow/whatsOnNowFile']"
+          :should-show-cta="true"
           class="u-color-group-dark"
           aria-live="polite"
           @togglePlay="togglePlay($store.getters['whatsOnNow/whatsOnNow'])"


### PR DESCRIPTION
Added the `should-show-cta` property to the persistent player to enable the "Listen Live" state.

Considered adding it to the store as a setting but not sure if that's the right place for a hardcoded setting that doesn't ever change. Thought of a few other ways to do it but they seemed a bit heavyweight for this one flag. Any suggested best practices around this?