### PR TITLE
WNYC-301 On Today's Show, People

### DIFF
--- a/components/OnTodaysShow.vue
+++ b/components/OnTodaysShow.vue
@@ -178,6 +178,11 @@ export default {
           image: 'http://placehold.it/120x120',
           name: 'Andrew Cuomo',
           role: 'Guest'
+        },
+        {
+          image: 'http://placehold.it/120x120',
+          name: 'Andrew Cuomo',
+          role: 'Guest'
         }
       ]
     }
@@ -213,17 +218,45 @@ export default {
 
 .on-todays-show-person-social-wrapper {
   display: flex;
+  flex-direction: column;
   width: 100%;
+  @include media(">medium") {
+    flex-direction: row;
+  }
 }
 
 .on-todays-show-person-list {
+  position: relative;
   flex: 1 1;
-  display: flex;
-  flex-basis: 360px;
-  max-width: 360px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  justify-items: center;
   @include media(">medium") {
-    flex-basis: 600px;
-    max-width: 600px;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    margin-right: 24px;
+    flex-basis: 328px;
+    max-width: 328px;
+  }
+  @include media(">860px") {
+    flex-basis: 560px;
+    align-self: center;
+    max-width: 560px;
+    margin-right: 48px;
+  }
+}
+
+.on-todays-show-person-list:after {
+  display: none;
+  @include media(">medium") {
+    content: "";
+    display: block;
+    position: absolute;
+    right: 0;
+    top: 0;
+    height: 100%;
+    opacity: 0.5;
+    border: 1px solid #EAEFF0;
+    height: 100%;
   }
 }
 
@@ -231,18 +264,19 @@ export default {
   flex: 1 0 180px;
   width: 180px;
   margin-top: 36px;
+  align-self: center;
   @include media(">medium") {
     margin: 0;
-    align-self: center;
   }
 }
 
 .on-todays-show-person-item {
   display: inline-block;
   list-style: none;
+  margin-bottom: 24px;
   width: 180px;
   @include media(">medium") {
-    width: 300px;
+    width: 280px;
   }
 }
 
@@ -251,8 +285,8 @@ export default {
   width: 180px;
   max-width: 180px;
   @include media(">medium") {
-    width: 300px;
-    max-width: 300px;
+    width: 280px;
+    max-width: 280px;
   }
 }
 
@@ -260,30 +294,8 @@ export default {
   flex-basis: 204px;
   max-width: 204px;
   @include media(">medium") {
-    flex-basis: 348px;
-    max-width: 348px;
+    flex-basis: 328px;
+    max-width: 328px;
   }
 }
-
-.on-todays-show-person-list[data-count="1"]  .on-todays-show-person-item {
-  position: relative;
-  margin-right: 24px;
-  @include media(">medium") {
-    margin-right: 48px;
-  }
-}
-
-.on-todays-show-person-list[data-count="1"] .on-todays-show-person-item:after {
-  content: "";
-    position: absolute;
-    right: 0;
-    top: 0;
-    height: 112px;
-    opacity: 0.5;
-    border: 1px solid #EAEFF0;
-    @include media(">medium") {
-      height: 100px;
-    }
-}
-
 </style>

--- a/components/OnTodaysShow.vue
+++ b/components/OnTodaysShow.vue
@@ -56,7 +56,27 @@
     </div>
       <v-spacer size="triple" />
       <lazy-hydrate ssr-only>
-        <share-tools label="Connect with the show!" layout="vertical">
+      <div class="on-todays-show-person-social-wrapper">
+        <ul class="on-todays-show-person-list">
+          <li class="on-todays-show-person-item">
+            <v-person
+              class="on-todays-show-person"
+              image="http://placehold.it/120x120"
+              name="Alison Stewart"
+              name-link="http://example.com"
+              role="Host"
+            />
+          </li>
+          <li class="on-todays-show-person-item">
+            <v-person
+              class="on-todays-show-person"
+              image="http://placehold.it/120x120"
+              name="Andrew Cuomo"
+              role="Guest"
+            />
+          </li>
+        </ul>
+        <share-tools class="on-todays-show-social" label="Connect with the show!" layout="vertical">
           <share-tools-item
             v-for="(socialshare, index) in social"
             :key="index"
@@ -64,8 +84,9 @@
             :username="socialshare.contact"
           />
         </share-tools>
+      </div>
       </lazy-hydrate>
-  </div>
+      </div>
 </template>
 
 <script>
@@ -82,7 +103,8 @@ export default {
     ShareTools: () => import('nypr-design-system-vue/src/components/ShareTools'),
     ShareToolsItem: () => import('nypr-design-system-vue/src/components/ShareToolsItem'),
     VButton: () => import('nypr-design-system-vue/src/components/VButton'),
-    VSpacer: () => import('nypr-design-system-vue/src/components/VSpacer')
+    VSpacer: () => import('nypr-design-system-vue/src/components/VSpacer'),
+    VPerson: () => import('nypr-design-system-vue/src/components/VPerson')
   },
   mixins: [whatsOnNow],
   data () {
@@ -171,3 +193,70 @@ export default {
   }
 }
 </script>
+
+<style lang="scss">
+.o-icon {
+  border: none;
+  fill: RGB(var(--color-text));
+  z-index: 10;
+}
+
+.o-icon:hover {
+  fill: RGB(var(--color-text));
+  opacity: var(--opacity-hover);
+}
+
+.on-todays-show-person-social-wrapper {
+  grid-column: 1 / 3;
+  display: flex;
+  width: 100%;
+}
+
+.on-todays-show-person-list {
+  flex: 1;
+  display: block;
+}
+
+.on-todays-show-social {
+  flex: 0 1 180px;
+  width: 180px;
+}
+
+.on-todays-show-person-item {
+  display: inline-block;
+  list-style: none;
+  width: 180px;
+  @include media(">medium") {
+    width: 300px;
+  }
+}
+
+.on-todays-show-person.card.person-card {
+  list-style: none;
+  width: 180px;
+  max-width: 180px;
+  @include media(">medium") {
+    width: 300px;
+    max-width: 300px;
+  }
+}
+
+.on-todays-show-person-item:only-child {
+    position: relative;
+    margin-right: 24px;
+}
+
+.on-todays-show-person-item:only-child:after {
+  content: "";
+    position: absolute;
+    right: 0;
+    top: 0;
+    height: 112px;
+    opacity: 0.5;
+    border: 1px solid #EAEFF0;
+    @include media(">medium") {
+      height: 100px;
+    }
+}
+
+</style>

--- a/components/OnTodaysShow.vue
+++ b/components/OnTodaysShow.vue
@@ -57,22 +57,14 @@
     <v-spacer size="triple" />
     <lazy-hydrate ssr-only>
       <div class="on-todays-show-person-social-wrapper">
-        <ul class="on-todays-show-person-list">
-          <li class="on-todays-show-person-item">
+        <ul class="on-todays-show-person-list" :data-count="people.length">
+          <li v-for="person in people" :key="person.name" class="on-todays-show-person-item">
             <v-person
               class="on-todays-show-person"
-              image="http://placehold.it/120x120"
-              name="Alison Stewart"
-              name-link="http://example.com"
-              role="Host"
-            />
-          </li>
-          <li class="on-todays-show-person-item">
-            <v-person
-              class="on-todays-show-person"
-              image="http://placehold.it/120x120"
-              name="Andrew Cuomo"
-              role="Guest"
+              :image="person.image"
+              :name="person.name"
+              :name-link="person.nameLink"
+              :role="person.role"
             />
           </li>
         </ul>
@@ -174,7 +166,20 @@ export default {
           contact: 'allofitwnyc',
           service: 'instagram'
         }],
-      segmentsToShow: 3
+      segmentsToShow: 3,
+      people: [
+        {
+          image: 'http://placehold.it/120x120',
+          name: 'Alison Stewart',
+          'name-link': 'http://example.com',
+          role: 'Host'
+        },
+        {
+          image: 'http://placehold.it/120x120',
+          name: 'Andrew Cuomo',
+          role: 'Guest'
+        }
+      ]
     }
   },
   mounted () {
@@ -207,19 +212,29 @@ export default {
 }
 
 .on-todays-show-person-social-wrapper {
-  grid-column: 1 / 3;
   display: flex;
   width: 100%;
 }
 
 .on-todays-show-person-list {
-  flex: 1;
-  display: block;
+  flex: 1 1;
+  display: flex;
+  flex-basis: 360px;
+  max-width: 360px;
+  @include media(">medium") {
+    flex-basis: 600px;
+    max-width: 600px;
+  }
 }
 
 .on-todays-show-social {
-  flex: 0 1 180px;
+  flex: 1 0 180px;
   width: 180px;
+  margin-top: 36px;
+  @include media(">medium") {
+    margin: 0;
+    align-self: center;
+  }
 }
 
 .on-todays-show-person-item {
@@ -241,12 +256,24 @@ export default {
   }
 }
 
-.on-todays-show-person-item:only-child {
-    position: relative;
-    margin-right: 24px;
+.on-todays-show-person-list[data-count="1"] {
+  flex-basis: 204px;
+  max-width: 204px;
+  @include media(">medium") {
+    flex-basis: 348px;
+    max-width: 348px;
+  }
 }
 
-.on-todays-show-person-item:only-child:after {
+.on-todays-show-person-list[data-count="1"]  .on-todays-show-person-item {
+  position: relative;
+  margin-right: 24px;
+  @include media(">medium") {
+    margin-right: 48px;
+  }
+}
+
+.on-todays-show-person-list[data-count="1"] .on-todays-show-person-item:after {
   content: "";
     position: absolute;
     right: 0;

--- a/components/OnTodaysShow.vue
+++ b/components/OnTodaysShow.vue
@@ -54,8 +54,8 @@
         <div class="dots" />
       </div>
     </div>
-      <v-spacer size="triple" />
-      <lazy-hydrate ssr-only>
+    <v-spacer size="triple" />
+    <lazy-hydrate ssr-only>
       <div class="on-todays-show-person-social-wrapper">
         <ul class="on-todays-show-person-list">
           <li class="on-todays-show-person-item">
@@ -85,8 +85,8 @@
           />
         </share-tools>
       </div>
-      </lazy-hydrate>
-      </div>
+    </lazy-hydrate>
+  </div>
 </template>
 
 <script>

--- a/components/OnTodaysShow.vue
+++ b/components/OnTodaysShow.vue
@@ -177,11 +177,7 @@ export default {
         {
           image: 'http://placehold.it/120x120',
           name: 'Andrew Cuomo',
-          role: 'Guest'
-        },
-        {
-          image: 'http://placehold.it/120x120',
-          name: 'Andrew Cuomo',
+          'name-link': 'http://example.com',
           role: 'Guest'
         }
       ]
@@ -291,9 +287,11 @@ export default {
 }
 
 .on-todays-show-person-list[data-count="1"] {
+  align-self: center;
   flex-basis: 204px;
   max-width: 204px;
   @include media(">medium") {
+    align-self: left;
     flex-basis: 328px;
     max-width: 328px;
   }


### PR DESCRIPTION
Adds the people section to the On Today's Show component.

I'm not 100% sure about this but [it seems like we've agreed](https://jira.wnyc.org/browse/DS-985) that the On Today's Show section is a component/layout that's unique to WNYC 3000, and we don't have white label designs or anything like that to build on top of, so I haven't moved the CSS to the design system.