### PR TITLE
Remove Feedback Button

### DIFF
--- a/components/WnycFooter.vue
+++ b/components/WnycFooter.vue
@@ -25,11 +25,11 @@
         </a>
       </div>
     </template>
-    <template v-slot:rightComponent>
+    <!--template v-slot:rightComponent>
       <div>
         <v-button label="Send Us Your Feedback" rel="noopener" href="https://www.surveymonkey.com/r/LGP2Z96" target="_blank" />
       </div>
-    </template>
+    </template-->
     <template v-slot:social>
       <div>
         <share-tools label="Connect">


### PR DESCRIPTION
Commenting out broken "Send Us Your Feedback" Button in the footer of https://www.wnyc.org/radio/.